### PR TITLE
Feature/adaptive strings

### DIFF
--- a/lib/ad_localize/constant.rb
+++ b/lib/ad_localize/constant.rb
@@ -2,6 +2,7 @@ module AdLocalize
   module Constant
     SUPPORTED_PLATFORMS = %w(ios android yml json)
     PLURAL_KEY_SYMBOL = :plural
+    ADAPTIVE_KEY_SYMBOL = :adaptive
     SINGULAR_KEY_SYMBOL = :singular
     COMMENT_KEY_SYMBOL = :comment
     INFO_PLIST_KEY_SYMBOL = :info_plist

--- a/lib/ad_localize/platform/ios_formatter.rb
+++ b/lib/ad_localize/platform/ios_formatter.rb
@@ -115,7 +115,10 @@ module AdLocalize::Platform
       filename = export_dir(locale).join(AdLocalize::Constant::IOS_PLURAL_EXPORT_FILENAME)
       xml_doc = nil
       if File.exist?(filename)
-        xml_doc = Nokogiri::XML::Builder.with(Nokogiri::XML(open(filename)).css('plist>dict').first) do |xml|
+        xml_content = Nokogiri::XML(open(filename)) do |config|
+          config.default_xml.noblanks # minimify xml
+        end
+        xml_doc = Nokogiri::XML::Builder.with(xml_content.css('plist>dict').first) do |xml|
           yield(xml)
         end
       else

--- a/lib/ad_localize/platform/ios_formatter.rb
+++ b/lib/ad_localize/platform/ios_formatter.rb
@@ -6,7 +6,13 @@ module AdLocalize::Platform
 
     def export(locale, data, export_extension = nil, substitution_format = nil)
       create_locale_dir(locale)
-      [AdLocalize::Constant::PLURAL_KEY_SYMBOL, AdLocalize::Constant::SINGULAR_KEY_SYMBOL, AdLocalize::Constant::INFO_PLIST_KEY_SYMBOL].each do |numeral_key|
+      all_symbols = [
+        AdLocalize::Constant::PLURAL_KEY_SYMBOL,
+        AdLocalize::Constant::ADAPTIVE_KEY_SYMBOL,
+        AdLocalize::Constant::SINGULAR_KEY_SYMBOL,
+        AdLocalize::Constant::INFO_PLIST_KEY_SYMBOL
+      ]
+      all_symbols.each do |numeral_key|
         numeral_data = data.select {|key, wording| wording.dig(locale.to_sym)&.key? numeral_key}
         if numeral_data.empty?
           AdLocalize::LOGGER.log(:info, :black, "[#{locale.upcase}] no #{numeral_key.to_s} keys were found to generate the file")
@@ -36,6 +42,54 @@ module AdLocalize::Platform
       )
     end
 
+    def write_plural(locale, plurals)
+      locale = locale.to_sym
+
+      append_to_localizable_plist(locale) do |xml|
+        plurals.each do |wording_key, translations|
+          xml.key wording_key
+          xml.dict {
+            xml.key "NSStringLocalizedFormatKey"
+            xml.string "%\#@key@"
+            xml.key "key"
+            xml.dict {
+              xml.key "NSStringFormatSpecTypeKey"
+              xml.string "NSStringPluralRuleType"
+              xml.key "NSStringFormatValueTypeKey"
+              xml.string "d"
+              translations[locale][AdLocalize::Constant::PLURAL_KEY_SYMBOL].each do |wording_type, wording_value|
+                xml.key wording_type
+                xml.string wording_value
+              end
+            }
+          }
+        end
+      end
+      AdLocalize::LOGGER.log(:debug, :black, "iOS plural [#{locale}] ---> DONE!")
+    end
+
+    def write_adaptive(locale, adaptives)
+      locale = locale.to_sym
+
+      append_to_localizable_plist(locale) do |xml|
+        adaptives.each do |wording_key, translations|
+          xml.key wording_key
+          xml.dict {
+            xml.key "NSStringVariableWidthRuleType"
+            xml.dict {
+              translations[locale][AdLocalize::Constant::ADAPTIVE_KEY_SYMBOL].each do |wording_type, wording_value|
+                xml.key wording_type
+                xml.string wording_value
+              end
+            }
+          }
+        end
+      end
+      AdLocalize::LOGGER.log(:debug, :black, "iOS adaptive [#{locale}] ---> DONE!")
+    end
+
+    private
+
     def write_localizable(locale:, singulars:, wording_type:, filename:)
       locale = locale.to_sym
 
@@ -57,37 +111,25 @@ module AdLocalize::Platform
       AdLocalize::LOGGER.log(:debug, :black, "iOS #{wording_type} [#{locale}] ---> DONE!")
     end
 
-    def write_plural(locale, plurals)
-      locale = locale.to_sym
-
-      xml_doc = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
-        xml.plist {
-          xml.dict {
-            plurals.each do |wording_key, translations|
-              xml.key wording_key
-              xml.dict {
-                xml.key "NSStringLocalizedFormatKey"
-                xml.string "%\#@key@"
-                xml.key "key"
-                xml.dict {
-                  xml.key "NSStringFormatSpecTypeKey"
-                  xml.string "NSStringPluralRuleType"
-                  xml.key "NSStringFormatValueTypeKey"
-                  xml.string "d"
-                  translations[locale][AdLocalize::Constant::PLURAL_KEY_SYMBOL].each do |wording_type, wording_value|
-                    xml.key wording_type
-                    xml.string wording_value
-                  end
-                }
-              }
-            end
+    def append_to_localizable_plist(locale)
+      filename = export_dir(locale).join(AdLocalize::Constant::IOS_PLURAL_EXPORT_FILENAME)
+      xml_doc = nil
+      if File.exist?(filename)
+        xml_doc = Nokogiri::XML::Builder.with(Nokogiri::XML(open(filename)).css('plist>dict').first) do |xml|
+          yield(xml)
+        end
+      else
+        xml_doc = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml.plist {
+            xml.dict {
+              yield(xml)
+            }
           }
-        }
+        end
       end
-      export_dir(locale).join(AdLocalize::Constant::IOS_PLURAL_EXPORT_FILENAME).open("w") do |file|
+      filename.open("w") do |file|
         file.puts xml_doc.to_xml(indent: 4)
       end
-      AdLocalize::LOGGER.log(:debug, :black, "iOS plural [#{locale}] ---> DONE!")
     end
   end
 end

--- a/test/exports_reference/ios/en.lproj/Localizable.stringsdict
+++ b/test/exports_reference/ios/en.lproj/Localizable.stringsdict
@@ -17,5 +17,17 @@
                 <string>Rate %1$@ stars</string>
             </dict>
         </dict>
+        <key>start_countdown</key>
+        <dict>
+            <key>NSStringVariableWidthRuleType</key>
+            <dict>
+                <key>20</key>
+                <string>Start</string>
+                <key>25</key>
+                <string>Start countdown</string>
+                <key>50</key>
+                <string>Start countdown</string>
+            </dict>
+        </dict>
     </dict>
 </plist>

--- a/test/exports_reference/ios/fr.lproj/Localizable.stringsdict
+++ b/test/exports_reference/ios/fr.lproj/Localizable.stringsdict
@@ -17,5 +17,17 @@
                 <string>Attribuer %1$@ étoiles</string>
             </dict>
         </dict>
+        <key>start_countdown</key>
+        <dict>
+            <key>NSStringVariableWidthRuleType</key>
+            <dict>
+                <key>20</key>
+                <string>Commencer</string>
+                <key>25</key>
+                <string>Commencer</string>
+                <key>50</key>
+                <string>Commencer le compte à rebours</string>
+            </dict>
+        </dict>
     </dict>
 </plist>

--- a/test/reference.csv
+++ b/test/reference.csv
@@ -12,3 +12,7 @@
 ,assess_rate_trip_voiceover##{other},Attribuer %1$@ étoiles,Si %1$@<=3 : prononcer également assess_comment_placeholder. Si %1$@>3 : prononcer également assess_optional_comment_placeholder,Rate %1$@ stars,
 #InfoPlist,,,,,
 ,NSCameraUsageDescription,Camera utilisé pour blabla,,Camera used for blabla,
+#Variadic width strings,,,,,
+,start_countdown##{20},Commencer,,Start,
+,start_countdown##{25},Commencer,,Start countdown,
+,start_countdown##{50},Commencer le compte à rebours,,Start countdown,


### PR DESCRIPTION
Handles [adaptive strings](https://developer.apple.com/documentation/foundation/nsstring/1413104-variantfittingpresentationwidth) for iOS.

The proposed format is : 
```
,start_countdown##{20},Commencer,,Start,
,start_countdown##{25},Commencer,,Start countdown,
,start_countdown##{50},Commencer le compte à rebours,,Start countdown,
```

to generate the following content in Localizable.strings:
```
<key>start_countdown</key>
<dict>
    <key>NSStringVariableWidthRuleType</key>
    <dict>
        <key>20</key>
        <string>Start</string>
        <key>25</key>
        <string>Start countdown</string>
        <key>50</key>
        <string>Start countdown</string>
    </dict>
</dict>
```