### PR TITLE
Accept activesupport 6 as dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    ad_localize (3.4.0)
-      activesupport (>= 4.2.10)
+    ad_localize (3.5.0)
+      activesupport (>= 5.2, < 7.0)
       colorize (~> 0.8)
-      googleauth (~> 0.12.0)
-      nokogiri (~> 1.8, >= 1.8.2)
+      googleauth (~> 0.12)
+      nokogiri (~> 1.10)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.2)
+    activesupport (6.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
@@ -24,7 +24,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
     diffy (3.3.0)
-    faraday (0.17.3)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     googleauth (0.12.0)
       faraday (>= 0.17.3, < 2.0)
@@ -35,7 +35,7 @@ GEM
       signet (~> 0.14)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    jwt (2.1.0)
+    jwt (2.2.1)
     memoist (0.16.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -45,11 +45,11 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     multi_json (1.14.1)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     os (1.1.0)
-    public_suffix (2.0.5)
+    public_suffix (4.0.5)
     rake (12.3.3)
     ruby-progressbar (1.10.1)
     signet (0.14.0)

--- a/ad_localize.gemspec
+++ b/ad_localize.gemspec
@@ -46,10 +46,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters', '~> 1.3'
   spec.add_development_dependency 'diffy', '~> 3.3'
 
-  spec.add_dependency 'activesupport', '~> 5.2'
+  spec.add_dependency 'activesupport', '>= 5.2', '< 7.0'
   spec.add_dependency 'nokogiri', '~> 1.10'
   spec.add_dependency 'colorize', '~> 0.8'
   spec.add_dependency 'googleauth', '~> 0.12'
 
-  spec.required_ruby_version     = '~> 2.3'
+  spec.required_ruby_version = '~> 2.3'
 end


### PR DESCRIPTION
It was not possible to use it in a Rails 6 project. Updated gemspec to handle both 5.2 and 6 versions of activesupport