### PR TITLE
Add properties as export format

### DIFF
--- a/lib/ad_localize.rb
+++ b/lib/ad_localize.rb
@@ -25,6 +25,7 @@ require 'ad_localize/platform/android_formatter'
 require 'ad_localize/platform/ios_formatter'
 require 'ad_localize/platform/json_formatter'
 require 'ad_localize/platform/yml_formatter'
+require 'ad_localize/platform/properties_formatter'
 
 module AdLocalize
   class Error < StandardError; end

--- a/lib/ad_localize/constant.rb
+++ b/lib/ad_localize/constant.rb
@@ -1,6 +1,6 @@
 module AdLocalize
   module Constant
-    SUPPORTED_PLATFORMS = %w(ios android yml json)
+    SUPPORTED_PLATFORMS = %w(ios android yml json properties)
     PLURAL_KEY_SYMBOL = :plural
     ADAPTIVE_KEY_SYMBOL = :adaptive
     SINGULAR_KEY_SYMBOL = :singular

--- a/lib/ad_localize/platform/properties_formatter.rb
+++ b/lib/ad_localize/platform/properties_formatter.rb
@@ -1,0 +1,25 @@
+module AdLocalize::Platform
+  class PropertiesFormatter < PlatformFormatter
+    def platform
+      :properties
+    end
+
+    def export(locale, data, export_extension = "properties", substitution_format = "java")
+      locale = locale.to_sym
+
+      platform_dir.join("#{locale.to_s}.#{export_extension}").open("a") do |file|
+        data.each do |key, wording|
+          singular_wording = wording.dig(locale, AdLocalize::Constant::SINGULAR_KEY_SYMBOL)
+          unless singular_wording.blank?
+            line = "#{key}=#{singular_wording}"
+            line << "\n"
+            file.puts line
+          end
+        end
+      end
+
+      AdLocalize::LOGGER.log(:debug, :green, "Properties [#{locale}] ---> DONE!")
+    end
+
+  end
+end

--- a/test/ad_localize_test.rb
+++ b/test/ad_localize_test.rb
@@ -60,7 +60,7 @@ class AdLocalizeTest < TestCase
   private
 
   def all_files
-    ios_files + android_files + json_files + yml_files
+    ios_files + android_files + json_files + yml_files + properties_files
   end
 
   def ios_files(with_platform_directory: true)
@@ -85,6 +85,11 @@ class AdLocalizeTest < TestCase
 
   def yml_files
     languages.map { |language| "yml/#{language}.yml" }
+  end
+
+
+  def properties_files
+    languages.map { |language| "properties/#{language}.properties" }
   end
 
   def languages

--- a/test/exports_reference/properties/en.properties
+++ b/test/exports_reference/properties/en.properties
@@ -1,0 +1,13 @@
+delete=Delete
+send=Send
+send_again=Send again
+quit=Quit
+done=Finish
+save=Save
+login.title=Login
+login.email.title=Email
+login.password=Password
+unescaped_format=String "unescaped"
+escaped_format=String \"escaped\"
+space_before_key=Value
+space_after_key=Value

--- a/test/exports_reference/properties/fr.properties
+++ b/test/exports_reference/properties/fr.properties
@@ -1,0 +1,13 @@
+delete=Supprimer
+send=Envoyer
+send_again=Renvoyer
+quit=Quitter
+done=Terminer
+save=Enregistrer
+login.title=Login
+login.email.title=Email
+login.password=Mot de passe
+unescaped_format=String "unescaped"
+escaped_format=String \"escaped\"
+space_before_key=Value
+space_after_key=Value


### PR DESCRIPTION
Hello 👋 

### Need
I have a project (reactNative for info) in which the string are stored as java properties (base format for https://github.com/mozilla/pontoon) so i need to export my locales in this format

### Solution
Just added this export format.
As it is a flat format currently plurals are just ignored