### PR TITLE
Use percent HTML char for escaping '%' on android

### DIFF
--- a/lib/ad_localize/mappers/android_translation_mapper.rb
+++ b/lib/ad_localize/mappers/android_translation_mapper.rb
@@ -9,7 +9,7 @@ module AdLocalize
         processedValue = processedValue.gsub(/(?<!\\)\"/, "\\\"") # match " unless there is a \ before
         processedValue = processedValue.gsub(/(%(\d+\$)?@)/, '%\2s') # should match values like %1$s and %s
         processedValue = processedValue.gsub(/(%((\d+\$)?(\d+)?)i)/, '%\2d') # should match values like %i, %3$i, %01i, %1$02i
-        processedValue = processedValue.gsub(/%(?!((\d+\$)?(s|(\d+)?d)))/, '%%') # negative lookahead: identifies when user really wants to display a %
+        processedValue = processedValue.gsub(/%(?!((\d+\$)?(s|(\d+)?d)))/, '&#37;') # negative lookahead: identifies when user really wants to display a %
         processedValue = processedValue.gsub("\\U", "\\u")
         "\"#{processedValue}\""
       end


### PR DESCRIPTION
The '%%' is sometime displayed a '%%' instead of '%'. With the HTML char, it is guaranteed to always work